### PR TITLE
Fix test mgrs

### DIFF
--- a/tests/test_mgrs.py
+++ b/tests/test_mgrs.py
@@ -24,9 +24,9 @@ class TestRunInput(unittest.TestCase):
     def setUpClass(cls):
         cls.temp_dir = tempfile.TemporaryDirectory()
 
-        mock_dir = shutil.copytree('tests/rsrc/mock_DSSAT', os.path.join(cls.temp_dir.name, 'DSSAT47'))
+        mock_dir = shutil.copytree('rsrc/mock_DSSAT', os.path.join(cls.temp_dir.name, 'DSSAT47'))
         set_dssat_dir(mock_dir)
-        cls.file = 'tests/rsrc/mock_DSSAT/Exper/Maize/BRPI0202.MZX'
+        cls.file = 'rsrc/mock_DSSAT/Exper/Maize/BRPI0202.MZX'
 
         cls.dssat_run = DSSATRun(cls.file)
         cls.ref_expfile = ExpFile(cls.file)
@@ -183,7 +183,7 @@ class TestRunOutput(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dir_ = 'tests/rsrc/mock_DSSAT/Out'
+        cls.dir_ = 'rsrc/mock_DSSAT/Out'
         cls.result = DSSATResults(cls.dir_)
 
     def test_get_value(self):

--- a/tests/test_mgrs.py
+++ b/tests/test_mgrs.py
@@ -24,9 +24,9 @@ class TestRunInput(unittest.TestCase):
     def setUpClass(cls):
         cls.temp_dir = tempfile.TemporaryDirectory()
 
-        mock_dir = shutil.copytree('rsrc/mock_DSSAT', os.path.join(cls.temp_dir.name, 'DSSAT47'))
+        mock_dir = shutil.copytree('tests/rsrc/mock_DSSAT', os.path.join(cls.temp_dir.name, 'DSSAT47'))
         set_dssat_dir(mock_dir)
-        cls.file = 'rsrc/mock_DSSAT/Exper/Maize/BRPI0202.MZX'
+        cls.file = 'tests/rsrc/mock_DSSAT/Exper/Maize/BRPI0202.MZX'
 
         cls.dssat_run = DSSATRun(cls.file)
         cls.ref_expfile = ExpFile(cls.file)
@@ -183,7 +183,7 @@ class TestRunOutput(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dir_ = 'rsrc/mock_DSSAT/Out'
+        cls.dir_ = 'tests/rsrc/mock_DSSAT/Out'
         cls.result = DSSATResults(cls.dir_)
 
     def test_get_value(self):

--- a/tradssat/mgrs/out.py
+++ b/tradssat/mgrs/out.py
@@ -4,14 +4,14 @@ from tradssat import SummaryOut, PlantGroOut, SoilWatOut, SoilNiOut, SoilTempOut
 class DSSATResults(object):
     """
     Facilitates the reading of DSSAT results. Instead of having to read each output file individually, you can simply
-    point this class to a DSSAT run output folder containing the output files and it will find the desired variables 
+    point this class to a DSSAT run output folder containing the output files and it will find the desired variables
     for you.
     """
 
     def __init__(self, folder):
         """
         Initialise with the base folder.
-        
+
         Parameters
         ----------
         folder: str
@@ -38,7 +38,7 @@ class DSSATResults(object):
     def get_value(self, var, trt, t=None, at='YEAR DOY'):
         """
         Returns the value (point or time-series) of a variable from a DSSAT run.
-        
+
         Parameters
         ----------
         var: str
@@ -76,7 +76,7 @@ class DSSATResults(object):
 
             if var in f.variables():
                 if t is None:
-                    return f.get_value(var)
+                    return f.get_value(var, sect={'TREATMENT': trt})
                 return f.get_value(var, sect={'TREATMENT': trt}, cond=cond)
 
         raise ValueError('Output variable "{}" could not be found in any output file.'.format(var))


### PR DESCRIPTION
Hello Julien,

I continue to work with traDSSAT to allow a better output processing for my work. So, I am always finding things that need fix. 

This days I found **two important things**. The first one comes with this PR.

1)  At least locally, the `test_mgrs` stop to present erros after the following modifications.

2) In the `DSSATResults` class, I found a typo in the method `get_var`. After checking my outputs, I realized that the function was always returning the `trt` 1.

I will wait for your evaluation.

The second thing I found (It's not present here), was that in the output header, the only variable available is `TREATMENT`. I'm using simulation through the years (like seasonal, but with daily outputs) , so, for each treatment, there are 30 simulations (one for each year). This information is in the `RUN` header variable. I think I found a solution, but I'm still testing.

Thanks!

Hope you find it useful.
