### PR TITLE
RMET is a character var

### DIFF
--- a/src/tradssat/exper/exper_vars.py
+++ b/src/tradssat/exper/exper_vars.py
@@ -192,7 +192,7 @@ main_vars = {
     FloatVar('RDEP', 5, 0, info='Residue incorporation depth, cm'),
 
     # Todo: check
-    FloatVar('RMET', 5, 0, info=''),
+    CharacterVar('RMET', 5, info='<same as FACD> Fertilizer application/placement, code'),
     CharacterVar('RENAME', 25, info='Residue management level name'),
 
     # CHEMICAL APPLICATIONS


### PR DESCRIPTION
In an RIX obtained from an academic institution, RMET is the same as FACD, a char var.  And DSSAT run successfully with RMET set to alpha numeric value such as follows:

*RESIDUES AND ORGANIC FERTILIZER
@R RDATE  RCOD  RAMT  RESN  RESP  RESK  RINP  RDEP  RMET RENAME
 1 85246 RE001   500   .53   -99   -99   -99    15 AP012 -99