### PR TITLE
fix: adjust alignment of values to soil headers

### DIFF
--- a/src/tradssat/tmpl/vals.py
+++ b/src/tradssat/tmpl/vals.py
@@ -391,8 +391,10 @@ class ValueSubSection(object):
         """
         self.check_dims()
         self.check_vals()
-
-        lines.append('@' + ''.join([vr.write() for vr in self]))
+        headers = ''.join([vr.write() for vr in self])
+        # Hack for soil SALB header
+        headers = '@' + headers[1:] if headers.startswith("   SLB") else '@' + headers
+        lines.append(headers)
         for i in range(self.n_data()):
             written = [vr.write(i) for vr in self]
             for i, (x, vr) in enumerate(zip(list(written), self)):
@@ -444,6 +446,15 @@ class VariableValue(object):
     """
 
     def __init__(self, var, val):
+        """_summary_
+
+        Parameters
+        ----------
+        var : Variable object
+            _description_
+        val : str, int, or floats
+            _description_
+        """
 
         self.changed = False
 

--- a/src/tradssat/tmpl/var.py
+++ b/src/tradssat/tmpl/var.py
@@ -12,6 +12,27 @@ class Variable(object):
     type_ = None
 
     def __init__(self, name, size, spc, header_fill, float_r, miss, sect, info):
+        """
+
+        Parameters
+        ----------
+        name : str
+            A DSSAT variable name
+        size : int
+            Allowed maximum width of the variable
+        spc : int
+            Number of required leading spaces
+        header_fill : str
+            A character with which to fill a header
+        float_r : bool
+            Flag to indicate whether a value is a float
+        miss : str
+            A substitute to indicate missing data, ie '-99'
+        sect : str
+            A section or subsection to which a variable corresponds
+        info : str
+            Description for the name
+        """
         self.name = name
         self.size = size
         self.spc = spc
@@ -33,8 +54,8 @@ class Variable(object):
             txt = self._write(val)
 
         if self.float_r:
-            return ' ' * self.spc + txt.ljust(self.size, fill)
-        return ' ' * self.spc + txt.rjust(self.size, fill)
+            return ' ' * self.spc + txt.rjust(self.size, fill)
+        return ' ' * self.spc + txt.ljust(self.size, fill)
 
     def check_val(self, val):
         raise NotImplementedError
@@ -75,7 +96,7 @@ class NumericVar(Variable):
 
     def __init__(self, name, size, lims, spc, header_fill, miss, sect, info):
 
-        super().__init__(name, size, spc, header_fill, sect=sect, float_r=True, miss=miss, info=info)
+        super().__init__(name, size=size, spc=spc, header_fill=header_fill, sect=sect, float_r=True, miss=miss, info=info)
 
         if lims is None:
             lims = (-np.inf, np.inf)
@@ -103,7 +124,30 @@ class FloatVar(NumericVar):
     type_ = float
 
     def __init__(self, name, size, dec, lims=None, spc=1, sect=None, header_fill=' ', miss='-99', info=''):
-        super().__init__(name, size, lims, spc, header_fill, miss=miss, sect=sect, info=info)
+        """_summary_
+
+        Parameters
+        ----------
+        name : _type_
+            _description_
+        size : _type_
+            _description_
+        dec : _type_
+            _description_
+        lims : _type_, optional
+            _description_, by default None
+        spc : int, optional
+            _description_, by default 1
+        sect : _type_, optional
+            _description_, by default None
+        header_fill : str, optional
+            _description_, by default ' '
+        miss : str, optional
+            _description_, by default '-99'
+        info : str, optional
+            _description_, by default ''
+        """
+        super().__init__(name, size=size, lims=lims, spc=spc, header_fill=header_fill, miss=miss, sect=sect, info=info)
         self.dec = dec
 
     def _write(self, val):


### PR DESCRIPTION
This PR address the following issue: https://github.com/julienmalard/traDSSAT/issues/32
* adjust the logic for justification of values wrt to their type, float vs non-float
* ensure the SLB header ends on column 7 to align with its values that also end on column 7. 

In the screenshot below, I compare the soil.SOL files from the original (left) to the one that this PR generates (right).  The alignment of the variables to the headers are improved, albeit not perfect.  However, I also verified that the results from the DSSAT simulation were the same. 
![Screen Shot 2022-06-15 at 1 18 11 PM](https://user-images.githubusercontent.com/28544467/173887208-03a122b2-b86a-40f9-9b6d-4b7f09ac45f4.png)

DSSAT run with the original soil.SOL file from DSSAT. 
![Screen Shot 2022-06-15 at 1 36 37 PM](https://user-images.githubusercontent.com/28544467/173890365-7879e5cc-791f-4b10-b13d-dde1a5f50283.png)

DSSAT run with newly created soil.SOL file from this `fix-soil-write` branch.
![Screen Shot 2022-06-15 at 1 22 55 PM](https://user-images.githubusercontent.com/28544467/173888038-3a4eb7db-bfdf-4ed8-92ad-ebb7757c13ad.png)
![Screen Shot 2022-06-15 at 1 24 23 PM](https://user-images.githubusercontent.com/28544467/173888268-a343b60d-4be5-472a-a94e-7586bfaa3d54.png)

